### PR TITLE
Do not remove anchor when drawing multiline text

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -224,7 +224,6 @@ def customimage(entity_id, service, hass):
             stroke_fill = element.get('stroke_fill', 'white')
             if "max_width" in element:
                 text = get_wrapped_text(str(element['value']), font, line_length=element['max_width'])
-                anchor = None
             else:
                 text = str(element['value'])
             d.text((element['x'],  akt_pos_y), text, fill=getIndexColor(color), font=font, anchor=anchor, align=align, spacing=spacing, stroke_width=stroke_width, stroke_fill=stroke_fill)


### PR DESCRIPTION
I am not sure why this was done in the first place, maybe because support for it was only added in Pillow v8? This way, multiline text can properly be drawn if for example the text is fully centered.