### PR TITLE
Switch default anchor for text from `lt` to `la`.

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -217,7 +217,7 @@ def customimage(entity_id, service, hass):
             else:
                 akt_pos_y = element['y']
             color = element.get('color', "black")
-            anchor = element.get('anchor', "lt")
+            anchor = element.get('anchor', "la")
             align = element.get('align', "left")
             spacing = element.get('spacing', 5)
             stroke_width = element.get('stroke_width', 0)

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -81,7 +81,7 @@ Draws text.
 - **color** (optional) font color of text. default: black
 - **y** (optional) position on y axis
 - **y_padding** (optional) offset to last text or multiline y position. works only if y is not provided. default: 10
-- **anchor** (optional) Position from the text, which shall be used as anchor. default: `lt` (left_top). Other options include `mm` (middle_middle). See https://pillow.readthedocs.io/en/stable/handbook/text-anchors.html
+- **anchor** (optional) Position from the text, which shall be used as anchor. default: `la` (left_ascending). Other options include `mm` (middle_middle). See https://pillow.readthedocs.io/en/stable/handbook/text-anchors.html
 - **max_width** (optional) creates line breaks in the provided text, if text is longer than `max_width` defines
 - **spacing** (optional) if line breaks created in the provided text using `max_width`, set spacing between single lines. Default: 5
 - **stroke_width** (optional) adds stroke around text with color `stroke_fill`. Default: 0
@@ -407,7 +407,7 @@ Draws a progress bar
 - **progress** (required) progress in percent, eg. `42`
 - **direction** (optional, default `right`) direction in which the progress bar should be filled, possible values are `right`, `left` `up`, `down`
 - **background** (optional, default `white`)
-- **fill** (optional, default `red`) color of the progress bar 
+- **fill** (optional, default `red`) color of the progress bar
 - **outline** (optional, default `black`) color of outline
 - **width** (optional, default `1`) width of outline
 - **visible** (optional, default `True`) show element


### PR DESCRIPTION
See https://github.com/OpenEPaperLink/Home_Assistant_Integration/pull/180#issuecomment-2402261058 for why.