### PR TITLE
Introducing 50% colors

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -31,8 +31,11 @@ _LOGGER = logging.getLogger(__name__)
 # Color constants with alpha channel
 WHITE = (255, 255, 255, 255)
 BLACK = (0, 0, 0, 255)
+HALF_BLACK = (127, 127, 127, 255)
 RED = (255, 0, 0, 255)
+HALF_RED = (255, 127, 127, 255)
 YELLOW = (255, 255, 0, 255)
+HALF_YELLOW = (255, 255, 127, 255)
 
 class ElementType(str, Enum):
     """Enum for supported element types."""
@@ -287,12 +290,20 @@ class ImageGen:
         color_str = str(color).lower()
         if color_str in ("black", "b"):
             return BLACK
-        elif color_str in ("accent", "red", "r", "yellow", "y"):
-            # Use the tag's accent color if "accent" is specified
-            if color_str == "accent":
-                return YELLOW if accent_color == "yellow" else RED
-            # Otherwise use the specifically requested color
-            return YELLOW if color_str in ("yellow", "y") else RED
+        if color_str in ("half_black", "hb", "gray", "grey", "g"):
+            return HALF_BLACK
+        elif color_str in ("accent", "a"):
+            return YELLOW if accent_color == "yellow" else RED
+        elif color_str in ("half_accent", "ha"):
+            return HALF_YELLOW if accent_color == "yellow" else HALF_RED
+        elif color_str in ("red", "r"):
+            return RED
+        elif color_str in ("half_red", "hr"):
+            return HALF_RED
+        elif color_str in ("yellow", "y"):
+            return YELLOW
+        elif color_str in ("half_yellow", "hy"):
+            return HALF_YELLOW
         else:
             return WHITE
 

--- a/custom_components/open_epaper_link/services.py
+++ b/custom_components/open_epaper_link/services.py
@@ -233,7 +233,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         fields = {
             'mac': mac,
             'contentmode': "25",
-            'dither': "1" if dither else "0",
+            'dither': "1" if dither else "2",
             'ttl': str(ttl),
             'image': ('image.jpg', img, 'image/jpeg'),
         }

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -32,7 +32,7 @@ Example payload:
 | `payload`    | List of drawing elements (YAML) | -       |
 | `background` | Background color                | white   |
 | `rotate`     | Rotation of image               | 0       |
-| `dither`     | Apply dithering to image        | false   |
+| `dither`     | Apply photo dithering to image  | false   |
 | `ttl`        | Cache time in seconds           | 60      |
 | `dry-run`    | Generate without sending        | false   |
 
@@ -47,8 +47,10 @@ Most dimensions (positions, sizes, etc.) can be specified in two ways:
 ESLs currently come in two variants: red and yellow accent colors. You can specify colors in several ways:
 
 - Using explicit colors: `"black"`, `"white"`, `"red"`, `"yellow"`
+- Using halftone colors (set `dither=false`): `"half_black"`, (or `"gray"`, or `"grey"`), `"half_red"`, `"half_yellow"`
 - Using single letter shortcuts: `"b"` (black), `"w"` (white), `"r"` (red), `"y"` (yellow)
-- Using `"accent"` to automatically use the tag's accent color (red or yellow depending on the hardware)
+- Using halftone shortcuts: `"hb"`, `"g"` (50% black), `"hr"` (50% red), `"hy"` (50% yellow)
+- Using `"accent"`, `"a"`, `"half_accent"`, or `"ha"` to automatically use the tag's accent color (red or yellow depending on the hardware)
 
 Example payload adapting to tag color:
 ```yaml


### PR DESCRIPTION
Half-colors (50% black, 50% accent) can rendered in a nice checkerboard style if we use `dither=2` when uploading the image to the AP.
We now use dither style 2 as default, i.e., if passing `dither=False` in the service data, that way we can use the 50% colors and it does not seem to have any significant other effect.
When showing photos, passing `dither=True` in the service data will use the dither style 1, just as before, existing setups that rely on dithering continue to work as before.

We introduce the following colors:

  - `half_black`, `hb`, `gray`, `grey`, `g`
  - `half_accent`, `ha`
  - `half_red`, `hr`
  - `half_yellow`, `hy`