### PR TITLE
Allow all three dithering methods

### DIFF
--- a/custom_components/open_epaper_link/services.yaml
+++ b/custom_components/open_epaper_link/services.yaml
@@ -38,11 +38,14 @@ drawcustom:
           step: 90
     dither:
       name: Dither
-      description: Whether to apply dithering to the image
+      description: Dithering option to use
       required: true
-      default: false
+      default: 2
       selector:
-        boolean:
+        number:
+          min: 0
+          max: 2
+          step: 1
     ttl:
       name: Time to live
       description: How long the image should be cached (in seconds)

--- a/custom_components/open_epaper_link/translations/de.json
+++ b/custom_components/open_epaper_link/translations/de.json
@@ -262,7 +262,7 @@
                 },
                 "dither": {
                     "name": "Dithering",
-                    "description": "Ob Dithering auf das Bild angewendet werden soll"
+                    "description": "Zu verwendende Dithering-Option"
                 },
                 "ttl": {
                     "name": "Gültigkeitsdauer",

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -32,9 +32,15 @@ Example payload:
 | `payload`    | List of drawing elements (YAML) | -       |
 | `background` | Background color                | white   |
 | `rotate`     | Rotation of image               | 0       |
-| `dither`     | Apply photo dithering to image  | false   |
+| `dither`     | Dithering (see table below)      | 2       |
 | `ttl`        | Cache time in seconds           | 60      |
 | `dry-run`    | Generate without sending        | false   |
+
+| Dither | Description                                           |
+|--------|-------------------------------------------------------|
+| `0`    | No dithering                                          |
+| `1`    | Floyd-Steinberg dithering (best for photos)           |
+| `2`    | Ordered dithering (default, best for halftone colors) |
 
 ## Using Dimensions
 
@@ -47,7 +53,7 @@ Most dimensions (positions, sizes, etc.) can be specified in two ways:
 ESLs currently come in two variants: red and yellow accent colors. You can specify colors in several ways:
 
 - Using explicit colors: `"black"`, `"white"`, `"red"`, `"yellow"`
-- Using halftone colors (set `dither=false`): `"half_black"`, (or `"gray"`, or `"grey"`), `"half_red"`, `"half_yellow"`
+- Using halftone colors (set `dither=2`): `"half_black"`, (or `"gray"`, or `"grey"`), `"half_red"`, `"half_yellow"`
 - Using single letter shortcuts: `"b"` (black), `"w"` (white), `"r"` (red), `"y"` (yellow)
 - Using halftone shortcuts: `"hb"`, `"g"` (50% black), `"hr"` (50% red), `"hy"` (50% yellow)
 - Using `"accent"`, `"a"`, `"half_accent"`, or `"ha"` to automatically use the tag's accent color (red or yellow depending on the hardware)

--- a/tests/drawcustom/conftest.py
+++ b/tests/drawcustom/conftest.py
@@ -57,7 +57,7 @@ def mock_service_data(payload):
     return {
         "background": "white",
         "rotate": 0,
-        "dither": False,
+        "dither": 2,
         "payload": payload
     }
 


### PR DESCRIPTION
OpenEPaperLink allows for three dithering options:
- disabled
- floyd-steinberg
- ordered

With the dither option as bool, we were limited to two of these options, now as int, we can have all! It defaults to option 2, ordered dithering.