### PR TITLE
fixed rotatebuffer

### DIFF
--- a/custom_components/open_epaper_link/image_decompressor.py
+++ b/custom_components/open_epaper_link/image_decompressor.py
@@ -18,11 +18,11 @@ def decode_esl_raw(data: bytes, tag_type: TagType) -> bytes:
     _LOGGER.debug(f"Tag type: {tag_type.name}")
     _LOGGER.debug(f"Dimensions: {tag_type.width}x{tag_type.height}")
     _LOGGER.debug(f"BPP: {tag_type.bpp}")
-    _LOGGER.debug(f"Rotate buffer: {tag_type.rotate_buffer}")
+    _LOGGER.debug(f"Rotate buffer: {tag_type.rotatebuffer}")
 
     # Calculate expected sizes
-    width = tag_type.height if tag_type.rotate_buffer % 2 else tag_type.width
-    height = tag_type.width if tag_type.rotate_buffer % 2 else tag_type.height
+    width = tag_type.height if tag_type.rotatebuffer % 2 else tag_type.width
+    height = tag_type.width if tag_type.rotatebuffer % 2 else tag_type.height
 
     if tag_type.bpp <= 2:  # Traditional 1-2 bit plane-based format
         bytes_per_row = (width + 7) // 8
@@ -151,7 +151,7 @@ def to_image(raw_data: bytes, tag_type: TagType) -> bytes:
     # For 90/270 degree rotated displays, swap width/height before processing
     native_width = tag_type.width
     native_height = tag_type.height
-    if tag_type.rotate_buffer % 2:  # 90 or 270 degrees
+    if tag_type.rotatebuffer % 2:  # 90 or 270 degrees
         native_width, native_height = native_height, native_width
 
 
@@ -235,11 +235,11 @@ def to_image(raw_data: bytes, tag_type: TagType) -> bytes:
                         pixels[x, y] = colors_list[color_index]
 
     # Apply rotation
-    if tag_type.rotate_buffer == 1:  # 90 degrees CCW
+    if tag_type.rotatebuffer == 1:  # 90 degrees CCW
         img = img.transpose(Image.Transpose.ROTATE_270)
-    elif tag_type.rotate_buffer == 2:  # 180 degrees
+    elif tag_type.rotatebuffer == 2:  # 180 degrees
         img = img.transpose(Image.Transpose.ROTATE_180)
-    elif tag_type.rotate_buffer == 3:  # 270 degrees CCW (90 CW)
+    elif tag_type.rotatebuffer == 3:  # 270 degrees CCW (90 CW)
         img = img.transpose(Image.Transpose.ROTATE_90)
 
     # Convert to JPEG

--- a/custom_components/open_epaper_link/tag_types.py
+++ b/custom_components/open_epaper_link/tag_types.py
@@ -25,7 +25,7 @@ class TagType:
         self.name = data.get('name', f"Unknown Type {type_id}")
         self.width = data.get('width', 296)
         self.height = data.get('height', 128)
-        self.rotate_buffer = data.get('rotate_buffer', 0)
+        self.rotatebuffer = data.get('rotatebuffer', 0)
         self.bpp = data.get('bpp', 2)
         self.color_table = data.get('colortable', {
             'white': [255, 255, 255],
@@ -47,7 +47,7 @@ class TagType:
             'name': self.name,
             'width': self.width,
             'height': self.height,
-            'rotate_buffer': self.rotate_buffer,
+            'rotatebuffer': self.rotatebuffer,
             'bpp': self.bpp,
             'colortable': self.color_table,
             'shortlut': self.short_lut,
@@ -66,7 +66,7 @@ class TagType:
             'name': data.get('name'),
             'width': data.get('width'),
             'height': data.get('height'),
-            'rotate_buffer': data.get('rotate_buffer'),
+            'rotatebuffer': data.get('rotatebuffer'),
             'bpp': data.get('bpp'),
             'shortlut': data.get('short_lut'),
             'colortable': data.get('colortable'),


### PR DESCRIPTION
This pull request includes changes to the `custom_components/open_epaper_link` module to standardize the naming of the `rotate_buffer` attribute across various functions and classes. The most important changes include updating the attribute name in the `TagType` class and all its references in the `image_decompressor.py` file.

Standardizing attribute naming:

* [`custom_components/open_epaper_link/image_decompressor.py`](diffhunk://#diff-1edca680162f1aed1587c8aac2352f02036e82d94c1415dc458a24b46f363b9bL21-R25): Changed all instances of `rotate_buffer` to `rotatebuffer` in the `decode_esl_raw`, `to_image`, and other related functions. [[1]](diffhunk://#diff-1edca680162f1aed1587c8aac2352f02036e82d94c1415dc458a24b46f363b9bL21-R25) [[2]](diffhunk://#diff-1edca680162f1aed1587c8aac2352f02036e82d94c1415dc458a24b46f363b9bL154-R154) [[3]](diffhunk://#diff-1edca680162f1aed1587c8aac2352f02036e82d94c1415dc458a24b46f363b9bL238-R242)
* [`custom_components/open_epaper_link/tag_types.py`](diffhunk://#diff-b08bd690c1b1e4ccb8a2810ef5f84878071cc2abec6e4e5204e3739fde8f4881L28-R28): Updated the `TagType` class to use `rotatebuffer` instead of `rotate_buffer` in the `__init__`, `to_dict`, and `from_dict` methods. [[1]](diffhunk://#diff-b08bd690c1b1e4ccb8a2810ef5f84878071cc2abec6e4e5204e3739fde8f4881L28-R28) [[2]](diffhunk://#diff-b08bd690c1b1e4ccb8a2810ef5f84878071cc2abec6e4e5204e3739fde8f4881L50-R50) [[3]](diffhunk://#diff-b08bd690c1b1e4ccb8a2810ef5f84878071cc2abec6e4e5204e3739fde8f4881L69-R69)