### PR TITLE
Remove unused switchbot.adv_parser import

### DIFF
--- a/custom_components/open_epaper_link/sensor.py
+++ b/custom_components/open_epaper_link/sensor.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Final
 
-from switchbot.adv_parser import model
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,


### PR DESCRIPTION
This import seems to be mistakenly added since it's not used. For those of us that don't use switchbot on Home Assistant, this import breaks the integration.