### PR TITLE
Restructure test setup.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,14 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest pytest-homeassistant-custom-component pytest-asyncio websockets
-
-      - name: Configure pytest
-        run: |
-          echo "[pytest]" > pytest.ini
-          echo "asyncio_mode = auto" >> pytest.ini
-          echo "testpaths = tests" >> pytest.ini
-          echo "asyncio_default_fixture_loop_scope = function" >> pytest.ini
+          pip install -r requirements_test.txt
 
       - name: Run tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ config/
 
 custom_components/open_epaper_link/*.jpg
 custom_components/open_epaper_link/lastapinteraction.txt
+
+tests/drawcustom/test_images/rename_me.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = [
+    "tests"
+]
+asyncio_default_fixture_loop_scope = "function"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 colorlog==6.7.0
-homeassistant==2024.2.0
+homeassistant
 pip>=21.0,<23.2
 ruff==0.0.292
 qrcode[pil]==7.4.2
 requests_toolbelt==1.0.0
+websockets
 websocket-client==1.7.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-asyncio
+pytest-homeassistant-custom-component


### PR DESCRIPTION
- Add requirements_test.txt for test package requirements.
- Create pyproject.toml for pytest.ini instead of building in github workflow.
- Unpin homeassistant version in requirements.txt.
- Add missing websockets library to requirements.txt.
- Add rename_me saved image from tests to gitignore.