### PR TITLE
multiline: allow to use 'parse_colors' option

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -628,6 +628,7 @@ class ImageGen:
         font_path = os.path.join(os.path.dirname(__file__), font_name)
         font = ImageFont.truetype(font_path, size)
         color = self.get_index_color(element.get('color', "black"))
+        align = element.get('align', "left")
         anchor = element.get('anchor', "lm")
         stroke_width = element.get('stroke_width', 0)
         stroke_fill = self.get_index_color(element.get('stroke_fill', 'white'))
@@ -638,15 +639,46 @@ class ImageGen:
 
         max_y = current_y
         for line in lines:
-            draw.text(
-                (element['x'], current_y),
-                str(line),
-                fill=color,
-                font=font,
-                anchor=anchor,
-                stroke_width=stroke_width,
-                stroke_fill=stroke_fill
-            )
+            if element.get('parse_colors', False):
+                segments = self._parse_colored_text(str(line))
+                segments, total_width = self._calculate_segment_positions(
+                    segments, font, element["x"], align
+                )
+
+                for segment in segments:
+                    color = self.get_index_color(segment.color, element.get('accent_color', 'red'))
+                    bbox = draw.textbbox(
+                        (segment.start_x, current_y),
+                        segment.text,
+                        font=font,
+                        anchor=anchor
+                    )
+                    draw.text(
+                        (segment.start_x, current_y),
+                        segment.text,
+                        fill=color,
+                        font=font,
+                        anchor=anchor,
+                        stroke_width=stroke_width,
+                        stroke_fill=stroke_fill
+                    )
+            else:
+                bbox = draw.textbbox(
+                    (element['x'], current_y),
+                    str(line),
+                    font=font,
+                    anchor=anchor,
+                    align=align
+                )
+                draw.text(
+                    (element['x'], current_y),
+                    str(line),
+                    fill=color,
+                    font=font,
+                    anchor=anchor,
+                    stroke_width=stroke_width,
+                    stroke_fill=stroke_fill
+                )
             current_y += element['offset_y']
             max_y = current_y
 

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -223,6 +223,11 @@ Splits text into multiple lines based on a delimiter.
 | `color`     | Text color                     | No       | `black`                   | `white`, `black`, `accent`, `red`, `yellow` |
 | `spacing`   | Additional line spacing        | No       | `0`                       | Pixels                                      |
 | `visible`   | Show/hide element              | No       | `true`                    | `true`, `false`                             |
+### Inline Color Markup
+
+Multiline elements support inline color markup when `parse_colors` is enabled. This allows different parts of the text to be rendered in different colors without needing to create multiple text elements.
+
+Please take a look at Text element documentation above.
 
 ### Line
 Draws a straight line.


### PR DESCRIPTION
'text' allows to have colours in 'value' so let allow the same for 'multiline'