### PR TITLE
Add deep sleep button, tag alias textbox

### DIFF
--- a/custom_components/open_epaper_link/button.py
+++ b/custom_components/open_epaper_link/button.py
@@ -39,6 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             ForceRefreshButton(hass, tag_mac, hub),
             RebootTagButton(hass, tag_mac, hub),
             ScanChannelsButton(hass, tag_mac, hub),
+            DeepSleepButton(hass, tag_mac, hub),
         ]
         async_add_entities(new_buttons)
 
@@ -226,6 +227,37 @@ class ScanChannelsButton(ButtonEntity):
 
     async def async_press(self) -> None:
         await send_tag_cmd(self.hass, self._entity_id, "scan")
+
+class DeepSleepButton(ButtonEntity):
+    def __init__(self, hass: HomeAssistant, tag_mac: str, hub) -> None:
+        """Initialize the button."""
+        self.hass = hass
+        self._tag_mac = tag_mac
+        self._entity_id = f"{DOMAIN}.{tag_mac}"
+        self._hub = hub
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "deep_sleep"
+        # self._attr_name = f"{hub._data[tag_mac]['tag_name']} Scan Channels"
+        self._attr_unique_id = f"{tag_mac}_deep_sleep"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_icon = "mdi:sleep"
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        tag_name = self._hub._data[self._tag_mac]['tag_name']
+        return {
+            "identifiers": {(DOMAIN, self._tag_mac)},
+            "name": tag_name,
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self._tag_mac not in self._hub.get_blacklisted_tags()
+
+    async def async_press(self) -> None:
+        await send_tag_cmd(self.hass, self._entity_id, "deepsleep")
 
 class RebootAPButton(ButtonEntity):
     def __init__(self, hass: HomeAssistant, hub) -> None:

--- a/custom_components/open_epaper_link/hub.py
+++ b/custom_components/open_epaper_link/hub.py
@@ -355,6 +355,21 @@ class Hub:
         # Get existing data to calculate runtime and update counters
         existing_data = self._data.get(tag_mac, {})
 
+        # Check if name has changed
+        old_name = existing_data.get("tag_name")
+        if old_name and old_name != tag_name:
+            _LOGGER.debug("Tag name changed from '%s' to '%s'", old_name, tag_name)
+            # Update device name in device registry
+            device_registry = dr.async_get(self.hass)
+            device = device_registry.async_get_device(
+                identifiers={(DOMAIN, tag_mac)}
+            )
+            if device:
+                device_registry.async_update_device(
+                    device.id,
+                    name=tag_name
+                )
+
         # Calculate runtime delta
         runtime_delta = self._calculate_runtime_delta(tag_data, existing_data)
         runtime_total = existing_data.get("runtime", 0) + runtime_delta

--- a/custom_components/open_epaper_link/manifest.json
+++ b/custom_components/open_epaper_link/manifest.json
@@ -15,7 +15,8 @@
   "requirements": [
     "qrcode[pil]==7.4.2",
     "requests_toolbelt==1.0.0",
-    "websocket-client==1.7.0"
+    "websocket-client==1.7.0",
+    "websockets==14.2"
   ],
   "single_config_entry": true,
   "version": "1.0.0"

--- a/custom_components/open_epaper_link/translations/de.json
+++ b/custom_components/open_epaper_link/translations/de.json
@@ -241,6 +241,9 @@
             "scan_channels": {
                 "name": "Kanäle scannen"
             },
+            "deep_sleep": {
+                "name": "Tiefschlaf"
+            },
             "reboot_ap": {
                 "name": "AP neu starten"
             },

--- a/custom_components/open_epaper_link/translations/de.json
+++ b/custom_components/open_epaper_link/translations/de.json
@@ -39,6 +39,9 @@
             },
             "repo": {
                 "name": "Repository"
+            },
+            "tag_alias": {
+                "name": "Alias"
             }
         },
         "select": {

--- a/custom_components/open_epaper_link/translations/en.json
+++ b/custom_components/open_epaper_link/translations/en.json
@@ -198,6 +198,9 @@
             "scan_channels": {
                 "name": "Scan Channels"
             },
+            "deep_sleep": {
+                "name": "Deep Sleep"
+            },
             "reboot_ap": {
                 "name": "Reboot AP"
             },

--- a/custom_components/open_epaper_link/translations/en.json
+++ b/custom_components/open_epaper_link/translations/en.json
@@ -39,6 +39,9 @@
             },
             "repo": {
                 "name": "Repository"
+            },
+            "tag_alias": {
+                "name": "Alias"
             }
         },
         "select": {


### PR DESCRIPTION
This pull request includes several enhancements and new features for the `custom_components/open_epaper_link` integration. The most important changes include the addition of a new button entity for deep sleep mode, updating the device name dynamically, and adding text entities for tag names/aliases.

New Features:

* [`custom_components/open_epaper_link/button.py`](diffhunk://#diff-0416c363a9b2580f00759078fe94cde50dca78087e3af56daf60352e26304530R42): Added a new `DeepSleepButton` entity to handle deep sleep commands. [[1]](diffhunk://#diff-0416c363a9b2580f00759078fe94cde50dca78087e3af56daf60352e26304530R42) [[2]](diffhunk://#diff-0416c363a9b2580f00759078fe94cde50dca78087e3af56daf60352e26304530R231-R261)
* [`custom_components/open_epaper_link/text.py`](diffhunk://#diff-25a45eb877fe009601e7781549526aebe564a1ada45f8bafe8ff1e3d3f7adffcL3-R5): Added new text entities for tag names/aliases and updated the setup to include these entities. [[1]](diffhunk://#diff-25a45eb877fe009601e7781549526aebe564a1ada45f8bafe8ff1e3d3f7adffcL3-R5) [[2]](diffhunk://#diff-25a45eb877fe009601e7781549526aebe564a1ada45f8bafe8ff1e3d3f7adffcL18-R20) [[3]](diffhunk://#diff-25a45eb877fe009601e7781549526aebe564a1ada45f8bafe8ff1e3d3f7adffcR34-R41) [[4]](diffhunk://#diff-25a45eb877fe009601e7781549526aebe564a1ada45f8bafe8ff1e3d3f7adffcR117-R199) [[5]](diffhunk://#diff-25a45eb877fe009601e7781549526aebe564a1ada45f8bafe8ff1e3d3f7adffcL118-R212) [[6]](diffhunk://#diff-25a45eb877fe009601e7781549526aebe564a1ada45f8bafe8ff1e3d3f7adffcR223-R242)

Enhancements:

* [`custom_components/open_epaper_link/hub.py`](diffhunk://#diff-68756d2b5fa6680f6b5e6ccfb86570b59991bc385eb8baf48737613b4c4d9911R358-R372): Updated the device name in the device registry when the tag name changes.

Dependency Updates:

* [`custom_components/open_epaper_link/manifest.json`](diffhunk://#diff-fa57887970ba8f230655bfdeb872dd7bf1bcb89e26e97c7ac1870429d084d144L18-R19): Added `websockets==14.2` to the requirements.

Localization:

* [`custom_components/open_epaper_link/translations/de.json`](diffhunk://#diff-bd3a6a1f28b3e490265593665347490994d95cf941e90976ad1730c84390a9dcR42-R44): Added translations for "Alias" and "Deep Sleep". [[1]](diffhunk://#diff-bd3a6a1f28b3e490265593665347490994d95cf941e90976ad1730c84390a9dcR42-R44) [[2]](diffhunk://#diff-bd3a6a1f28b3e490265593665347490994d95cf941e90976ad1730c84390a9dcR244-R246)
* [`custom_components/open_epaper_link/translations/en.json`](diffhunk://#diff-fbe5dc6429b703f3a7d01748fd14e8b920f7795483e7bbda1815245d36099bd4R42-R44): Added translations for "Alias" and "Deep Sleep". [[1]](diffhunk://#diff-fbe5dc6429b703f3a7d01748fd14e8b920f7795483e7bbda1815245d36099bd4R42-R44) [[2]](diffhunk://#diff-fbe5dc6429b703f3a7d01748fd14e8b920f7795483e7bbda1815245d36099bd4R201-R203)