### PR TITLE
feat: Add Show timestamp switch to the AP device

### DIFF
--- a/custom_components/open_epaper_link/switch.py
+++ b/custom_components/open_epaper_link/switch.py
@@ -33,6 +33,12 @@ SWITCH_ENTITIES = [
         "name": "Nightly Reboot",
         "icon": "mdi:restart",
         "description": "Enable/disable automatic nightly reboot of the AP"
+    },
+    {
+        "key": "showtimestamp",
+        "name": "Show Timestamp",
+        "icon": "mdi:clock",
+        "description": "Enable/disable showing timestamps on ESLs"
     }
 ]
 

--- a/custom_components/open_epaper_link/translations/de.json
+++ b/custom_components/open_epaper_link/translations/de.json
@@ -32,6 +32,9 @@
             },
             "nightlyreboot": {
                 "name": "Nächtlicher Neustart"
+            },
+            "showtimestamp": {
+                "name": "Zeitstempel anzeigen"
             }
         },
         "text": {

--- a/custom_components/open_epaper_link/translations/en.json
+++ b/custom_components/open_epaper_link/translations/en.json
@@ -32,6 +32,9 @@
             },
             "nightlyreboot": {
                 "name": "Nightly Reboot"
+            },
+            "showtimestamp": {
+                "name": "Show Timestamp"
             }
         },
         "text": {

--- a/custom_components/open_epaper_link/translations/pt.json
+++ b/custom_components/open_epaper_link/translations/pt.json
@@ -32,7 +32,10 @@
       },
       "nightlyreboot": {
         "name": "Reinício Noturno"
-      }
+      },
+        "showtimestamp": {
+            "name": "Mostrar carimbo de tempo"
+        }
     },
     "text": {
       "alias": {


### PR DESCRIPTION
This pull request adds a new feature to the `open_epaper_link` custom component, enabling the option to show timestamps on ESLs. The changes include updates to the switch configuration and translations for multiple languages.

Key changes:

* Added the "Show Timestamp" option to the switch configuration in `custom_components/open_epaper_link/switch.py`.

Translation updates:

* Added the "Show Timestamp" translation to the German language file `custom_components/open_epaper_link/translations/de.json`.
* Added the "Show Timestamp" translation to the English language file `custom_components/open_epaper_link/translations/en.json`.
* Added the "Show Timestamp" translation to the Portuguese language file `custom_components/open_epaper_link/translations/pt.json`.