### PR TITLE
feat(imagegen): Add resize method for downloaded image

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -22,6 +22,7 @@ from .const import DOMAIN, SIGNAL_TAG_IMAGE_UPDATE
 from .tag_types import TagType, get_tag_types_manager
 from .util import get_image_path
 from PIL import Image, ImageDraw, ImageFont
+from resizeimage import resizeimage
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.history import get_significant_states
@@ -1966,6 +1967,7 @@ class ImageGen:
             pos_y = element['y']
             target_size = (element['xsize'], element['ysize'])
             rotate = element.get('rotate', 0)
+            resize_method = element.get('resize_method', 'stretch')
 
             # Check if URL is an image entity
             if element['url'].startswith('image.') or element['url'].startswith('camera.'):
@@ -2023,7 +2025,10 @@ class ImageGen:
 
             # Resize if needed
             if source_img.size != target_size:
-                source_img = source_img.resize(target_size)
+                if resize_method in ['crop', 'cover', 'contain']:
+                    source_img = resizeimage.resize(resize_method, source_img, target_size)
+                if source_img.size != target_size:
+                    source_img = source_img.resize(target_size)
 
             # Convert to RGBA
             source_img = source_img.convert("RGBA")

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -561,15 +561,16 @@ Downloads and displays an image from a URL.
   rotate: 0
 ```
 
-| Parameter | Description       | Required | Default | Notes                                                       |
-|-----------|-------------------|----------|---------|-------------------------------------------------------------|
-| `url`     | Image URL or path | Yes      | -       | HTTP/HTTPS URL, Data URI, local path or camera/image entity |
-| `x`       | X position        | Yes      | -       | Pixels                                                      |
-| `y`       | Y position        | Yes      | -       | Pixels                                                      |
-| `xsize`   | Target width      | Yes      | -       | Pixels                                                      |
-| `ysize`   | Target height     | Yes      | -       | Pixels                                                      |
-| `rotate`  | Rotation angle    | No       | `0`     | Degrees                                                     |
-| `visible` | Show/hide element | No       | `true`  | `true`, `false`                                             |
+| Parameter       | Description       | Required | Default   | Notes                                                       |
+|-----------------|-------------------|----------|-----------|-------------------------------------------------------------|
+| `url`           | Image URL or path | Yes      | -         | HTTP/HTTPS URL, Data URI, local path or camera/image entity |
+| `x`             | X position        | Yes      | -         | Pixels                                                      |
+| `y`             | Y position        | Yes      | -         | Pixels                                                      |
+| `xsize`         | Target width      | Yes      | -         | Pixels                                                      |
+| `ysize`         | Target height     | Yes      | -         | Pixels                                                      |
+| `resize_method` | Resizing method   | No       | `stretch` | `stretch`, `crop`, `cover`, `contain`                       |
+| `rotate`        | Rotation angle    | No       | `0`       | Degrees                                                     |
+| `visible`       | Show/hide element | No       | `true`    | `true`, `false`                                             |
 
 Notes:
 - Local images must be in `/config/media/`

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ qrcode[pil]==7.4.2
 requests_toolbelt==1.0.0
 websockets
 websocket-client==1.7.0
+python-resize-image==1.1.20


### PR DESCRIPTION
I want to display an image of dynamic size and implemented a custom resize method in the `dlimg` handler. I do think that others could find this feature useful al well.

The default behavior is unchanged and the changes are tested successfully.