### PR TITLE
fix(plot): update time retrieval to use local time instead of UTC

### DIFF
--- a/custom_components/open_epaper_link/imagegen.py
+++ b/custom_components/open_epaper_link/imagegen.py
@@ -2088,7 +2088,7 @@ class ImageGen:
 
             # Get time range
             duration = timedelta(seconds=element.get("duration", 60 * 60 * 24))
-            end = dt.utcnow()
+            end = dt.now()
             start = end - duration
 
             # Set up font


### PR DESCRIPTION
This pull request modifies the `custom_components/open_epaper_link/imagegen.py` file to update the method for retrieving the current time. Specifically, it replaces `dt.utcnow()` with `dt.now()` in the `_draw_plot` function for better alignment with local time handling.

* [`custom_components/open_epaper_link/imagegen.py`](diffhunk://#diff-bcf01b5b48cda13595626c76b54bc63950b51964dfff419009c25c459995b848L2091-R2091): Changed from `dt.utcnow()` to `dt.now()` in `_draw_plot` to use local time instead of UTC.

fixes #263 and #262 