### PR TITLE
Change websocket requirement to >= 14.2

### DIFF
--- a/custom_components/open_epaper_link/manifest.json
+++ b/custom_components/open_epaper_link/manifest.json
@@ -16,7 +16,7 @@
     "qrcode[pil]==7.4.2",
     "requests_toolbelt==1.0.0",
     "websocket-client==1.7.0",
-    "websockets==14.2",
+    "websockets>=14.2",
     "python-resize-image==1.1.20"
   ],
   "single_config_entry": true,


### PR DESCRIPTION
This fixes #279 as required for HA 2025.8 onwards because apparently that requires a different (newer) websocket lib version.